### PR TITLE
Made some changes throughout for style and clarity

### DIFF
--- a/organogram-upload.md
+++ b/organogram-upload.md
@@ -3,27 +3,27 @@ layout: "default"
 title: "Organogram upload"
 ---
 
-You can now (from 3rd October 2016) upload organogram data (sometimes called ‘organogram returns’) to data.gov.uk.
+From 3 October 2016, you can upload organogram data (sometimes called 'organogram returns') to data.gov.uk. 
 
 Before you start, you must:
 
 * [read our guidance] to find out what data your organisation must publish
-* get a copy of the previous organogram spreadsheet or download a fresh [spreadsheet template]
-* fill out the spreadsheet with your organization data
+* get a copy of the previous organogram spreadsheet or [download a new spreadsheet template]
+* fill out the spreadsheet with your organisation data
 
 ## Get an editor account on data.gov.uk
 
-Publishers need to get themselves an account on data.gov.uk and apply for 'editor' or 'admin' permissions added to it. To avoid delays when you come to upload the next set of data, please do this in advance.
+You must have a data.gov.uk account with 'editor' or 'admin' permissions to publish organogram data. 
 
-1. Log in to data.gov.uk <https://data.gov.uk/user>. Or if you don’t have an account, [create an account](becoming_an_editor_or_admin.html#getting-an-account)
+1. [Sign in to data.gov.uk](https://data.gov.uk/user) or create an account if you don't already have one. 
 
-2. Check if your account has ‘editor’ permissions for your publisher by looking for the blue 'Publisher Tools' button at top-right. If you have it, click on it and check your organization is listed.
+2. Click the 'Publisher tools' button in the top menu to see if you have 'editor' permissions. Your organisation will appear in the drop-down menu if you do.  
 
    ![organogram diagram](images/publisher_tools_button.png)
 
-3. If you don’t have the ‘Publisher Tools’ button, or your organization isn’t listed in its drop-down, [request to become an 'editor'](becoming_an_editor_or_admin.html#become-an-editor).
+3. If you can't see the 'Publisher tools' button or your organisation in the drop-down menu, [apply to become an 'editor'].  
 
-4. If you requested to become an editor and haven’t heard back for a couple of days, [contact the data.gov.uk team].
+Email <team@data.gov.uk> if you applied to become an editor and haven't heard back for a couple of days. 
 
 
 ## View your organograms
@@ -53,13 +53,11 @@ Publishers need to get themselves an account on data.gov.uk and apply for 'edito
 
    ![organogram upload](images/organogram_uploaded.png)
 
-4. You can see how the organogram will look when it’s published by clicking the ‘Preview’ link.
+4. You can see how the organogram will look when it's published by clicking the 'Preview' link. Only users who have a data.gov.uk account with 'editor' permissions will be able to see this preview. 
 
    ![organogram preview](images/organogram_preview.png)
 
-5. You must tick the ‘Sign off’ box before you can publish the organogram. Only do this when senior approval has been given - for departments that would be from your minister or permanent secretary.
-
-    Note: In the previous system the preview was made available as a separate web page, with a link that could be distributed without requiring log-in. This is no longer the case. This pre-publication preview can only be seen while logged in as a publisher.
+5. You must tick the ‘Sign off’ box before you can publish the organogram. Only do this when senior approval has been given - for departments that would be from your minister or permanent secretary.  
 
 6. You’ll now be able to click the ‘Publish’ button.
 
@@ -69,7 +67,7 @@ Publishers need to get themselves an account on data.gov.uk and apply for 'edito
 
    ![organogram dataset](images/organogram_dataset.png)
 
-   The diagram is under the "Organogram viewer" Link:
+   Click ‘Link’ under ‘Organogram viewer’ to see it. 
 
    ![organogram diagram link](images/organogram_diagram_link.png)
    ![organogram diagram](images/organogram_diagram.png)
@@ -80,7 +78,7 @@ Publishers need to get themselves an account on data.gov.uk and apply for 'edito
 
 2. Click the ‘Delete’ button next to it. This will remove the file from data.gov.uk.
 
-3. You can now upload the updated file. Find the completed spreadsheet file on your computer and click ‘Upload’. You’ll see an error message if there’s a problem with the file you’re trying to upload.
+3. You can now upload the updated file. Find the completed spreadsheet file on your computer and click ‘Upload’. You’ll see an error message if there’s a [problem with the file] you’re trying to upload.
 
 4. You’ll be sent back to the ‘Organogram publication’ page when your file is uploaded. You can see how the organogram will look when it’s published by clicking the ‘Preview’ link.
 
@@ -95,9 +93,9 @@ You won’t be able to upload your organogram to data.gov.uk if there are any er
 
 When you’re filling it in, make sure:
 
-* use the drop-down for the columns which have it, eg 'Parent Department' or 'Grade'
-* roles don't report to themselves
-* roles don't report to a role that is eliminated
-* the Valid? column is green for every row
+- you don’t write in fields which should be filled in using options from a drop-down menu, such as ‘Parent Department’ or ‘Grade’
+- roles don’t report to themselves
+- roles don’t report to a role that no longer exists
+- the ‘Valid?’ column is green for every row  
 
 Check your spreadsheet and try to upload it again. Please refer to the guidance, which explains in detail how to complete every column. If you’re still having problems, email <team@data.gov.uk> with ‘Organogram issues - help’ in the subject line.


### PR DESCRIPTION
Changed
You can now (from 3rd October 2016) upload organogram data (sometimes called ‘organogram returns’) to data.gov.uk.

To
From 3 October 2016, you can upload organogram data (sometimes called 'organogram returns') to data.gov.uk.  

Reason
Reads a bit better. Also changed how the date is written to be in GDS style.  

—

Changed
- get a copy of the previous organogram spreadsheet or download a fresh [spreadsheet template]

To
- get a copy of the previous organogram spreadsheet or [download a new spreadsheet template]

Reason
Make the action the link text. Also, "new" is plainer than "fresh".  

—

Changed
... with your organization data

To
... with your organisation data  

Reason
Typo - "organization" is the American spelling. This spelling pops up again later on, so I’ve gone through and changed it where it's been used.

—
## Get an editor account on data.gov.uk

Changed
Publishers need to get themselves an account on data.gov.uk and apply for ‘editor’ or ‘admin’ permissions added to it. To avoid delays when you come to upload the next set of data, please do this in advance.

To
You must have a data.gov.uk account with 'editor' or 'admin' permissions to publish organogram data.  

Reason
More active and clearer this is a condition of uploading organogram data. 

—

Changed
1. Log in to data.gov.uk https://data.gov.uk/user. Or if you don’t have an account, create an account

To
1. [Sign in to data.gov.uk](https://data.gov.uk/user) or create an account if you don't already have one. 

Reason
Put the link behind the text. 

—

Changed
2. Check if your account has ‘editor’ permissions for your publisher by looking for the blue ‘Publisher Tools’ button at top-right. If you have it, click on it and check your organization is listed.

To
2. Click the 'Publisher tools' button in the top menu to see if you have 'editor' permissions. Your organisation will appear in the drop-down menu if you do. 

Reason
Lead with the action, which is to click on the 'Publisher tools' button. Try to avoid referring to it as being blue - some users could be colourblind and unable to tell whether it's blue or not. 

—

Changed
4. If you requested to become an editor and haven’t heard back for a couple of days, [contact the data.gov.uk team].

To
Email team@data.gov.uk if you applied to become an editor and haven't heard back for a couple of days.

Reason
Suggest separating this from the numbered steps as it's not something all users will have to do. Can we give a more specific time than "a couple of days"?  

—
## Uploading and publishing a new organgogram

Changed
3. Find the completed spreadsheet file on your computer and click ‘Upload’. If you get an error message, see: [Problems with uploading organograms].

To
3. Find the completed spreadsheet file on your computer and click ‘Upload’. You’ll see an error message if there’s a [problem with the file] you’re trying to upload.

Reason
Better to link contextually behind the text. I’ve also repeated this in step 3 of the ‘Update an existing organogram’ section.

— 

Changed
4. You can see how the organogram will look when it’s published by clicking the ‘Preview’ link.

To
4. You can see how the organogram will look when it's published by clicking the 'Preview' link. Only users who have a data.gov.uk account with 'editor' permissions will be able to see this preview. 

Reason
I've tried to condense some of the information in the note underneath step 5 and add it to this step, as it pertains to seeing the preview link. 

—

Removed
Note: In the previous system the preview was made available as a separate web page, with a link that could be distributed without requiring log-in. This is no longer the case. This pre-publication preview can only be seen while logged in as a publisher.

Reason 
No longer needed as I've incorporated this information into step 4.  

— 

Changed
The diagram is under the “Organogram viewer” Link:

To
Click ‘Link’ under ‘Organogram viewer’ to see it. 

Reason
Again, a bit more active. 

—
## Problems with uploading organograms

Changed
When you’re filling it in, make sure:
- use the drop-down for the columns which have it, eg ‘Parent Department’ or ‘Grade’
- roles don’t report to themselves
- roles don’t report to a role that is eliminated
- the Valid? column is green for every row

To
When you’re filling it in, make sure:
- you don’t write in fields which should be filled in using options from a drop-down menu, such as ‘Parent Department’ or ‘Grade’
- roles don’t report to themselves
- roles don’t report to a role that no longer exists
- the ‘Valid?’ column is green for every row

Reason
The first bullet didn’t follow on from the lead-in sentence. The first bullet was quite confusing - think the wording I suggested earlier was a bit clearer.
